### PR TITLE
Fix server instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The code is kept as simple as possible, so no build scripts or anything. You wil
 
 One way to do this is by using Python’s SimpleHTTPServer, but there are many alternative ways.
 
-```python -m “SimpleHTTPServer”```
+```python -m "SimpleHTTPServer"```
 
  Screenshots
 ------------


### PR DESCRIPTION
The quotation marks cause a problem on my system:

`/usr/bin/python: No module named “SimpleHTTPServer”`

Changing them to normal `"` fixes things.